### PR TITLE
Update build.yml to use python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This PR upgrades python version for dev docs build. Currently we still use python 3.9 which blocks a number of dependencies to low values.