### PR TITLE
Upgrade Python version from 3.11 to 3.12 for dev doc workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This PR updates python version from 3.11 to 3.12 for dev doc build