### PR TITLE
Upgrade Python version from 3.11 to 3.12 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This is required since gammapy requires python>=3.12